### PR TITLE
fix: 本番環境ビルド時にdata-testitを除外する

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,18 @@
 import { withSentryConfig } from "@sentry/nextjs";
+
+const isProd = process.env.NODE_ENV === "production";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	pageExtensions: ["page.tsx", "page.ts"],
-	reactStrictMode: false,
+	reactStrictMode: true,
+	...(isProd && {
+		compiler: {
+			reactRemoveProperties: {
+				properties: ["^data-testid$"],
+			},
+		},
+	}),
 };
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
### **User description**
#154
#124


___

### **PR Type**
enhancement


___

### **Description**
- 本番環境でのビルド時に`data-testid`プロパティを除外する設定を追加しました。
- `reactStrictMode`を有効にしました。
- 本番環境かどうかを判定するための変数`isProd`を追加しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.mjs</strong><dd><code>Enhance production build configuration in Next.js</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.mjs

<li>Added a check for production environment.<br> <li> Enabled <code>reactStrictMode</code>.<br> <li> Configured removal of <code>data-testid</code> properties in production builds.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/155/files#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

