### PR TITLE
UT: Jestでテストする getServerSideProps

### DIFF
--- a/src/pages/articles/[id]/_server/index.test.tsx
+++ b/src/pages/articles/[id]/_server/index.test.tsx
@@ -1,0 +1,126 @@
+import { toMock } from "@/__testing__/helper";
+import { fetchArticleById } from "@/core/repositories/article/articles.repository";
+import { mockArticle1 } from "mocks/fixtures/article";
+import { getServerSideProps } from "./index";
+import { transformError } from "./transformError";
+
+jest.mock("@/core/repositories/article/articles.repository");
+jest.mock("./transformError");
+
+describe(getServerSideProps, () => {
+	beforeAll(() => {});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+		jest.restoreAllMocks();
+	});
+
+	describe("正常系", () => {
+		it("取得したデータを返却する", async () => {
+			// Arrange
+			const context = {
+				res: {
+					statusCode: 200,
+				},
+				params: {
+					id: "1",
+				},
+				// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			} as any;
+			const fetcherMock = toMock(fetchArticleById).mockResolvedValue({
+				response: {
+					data: mockArticle1,
+					status: 200,
+					statusText: "OK",
+				},
+			});
+
+			// Act
+			const res = await getServerSideProps(context);
+
+			// Assert
+			expect(fetcherMock).toHaveBeenCalled();
+			expect(res).toEqual({
+				props: {
+					article: mockArticle1,
+				},
+			});
+			expect(context.res.statusCode).toBe(200);
+		});
+	});
+
+	describe("異常系", () => {
+		describe("パラメータが不正", () => {
+			it("400エラーの値を返す", async () => {
+				// Arrange
+				const context = {
+					res: {
+						statusCode: 200,
+					},
+					params: {
+						id: "aaaaa",
+					},
+					// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+				} as any;
+				const fetcherMock = toMock(fetchArticleById);
+				toMock(transformError).mockReturnValue({
+					status: 400,
+					// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+				} as any);
+
+				// Act
+				const res = await getServerSideProps(context);
+
+				// Assert
+				expect(fetcherMock).not.toHaveBeenCalled();
+				expect(context.res.statusCode).toBe(400);
+				expect(transformError).toHaveBeenCalled();
+				expect(res).toEqual({
+					props: {
+						error: {
+							status: 400,
+						},
+					},
+				});
+			});
+		});
+
+		describe("fetchエラー", () => {
+			it("エラーコードの値を返す", async () => {
+				// Arrange
+				const context = {
+					res: {
+						statusCode: 200,
+					},
+					params: {
+						id: "1",
+					},
+					// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+				} as any;
+				const fetcherMock = toMock(fetchArticleById).mockResolvedValue({
+					// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+					error: {} as any,
+				});
+				toMock(transformError).mockReturnValue({
+					status: 404,
+					// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+				} as any);
+
+				// Act
+				const res = await getServerSideProps(context);
+
+				// Assert
+				expect(fetcherMock).toHaveBeenCalled();
+				expect(context.res.statusCode).toBe(404);
+				expect(transformError).toHaveBeenCalled();
+				expect(res).toEqual({
+					props: {
+						error: {
+							status: 404,
+						},
+					},
+				});
+			});
+		});
+	});
+});

--- a/src/pages/articles/[id]/_server/index.tsx
+++ b/src/pages/articles/[id]/_server/index.tsx
@@ -15,10 +15,11 @@ export const getServerSideProps: GetServerSideProps = async ({
 		const result = validateParams(params);
 		// 検査例外は個別に処理する
 		if ("error" in result) {
-			res.statusCode = result.error.status; // ステータスコードをセットする
+			const formatError = transformError(result.error);
+			res.statusCode = formatError.status;
 			return {
 				props: {
-					error: transformError(result.error),
+					error: formatError,
 				},
 			};
 		}
@@ -29,10 +30,11 @@ export const getServerSideProps: GetServerSideProps = async ({
 		// 3. 例: APIでデータ取得(エラーの場合は内部で)
 		const fetchResult = await fetchArticleById(result.params.id);
 		if ("error" in fetchResult) {
-			res.statusCode = fetchResult.error.status;
+			const formatError = transformError(fetchResult.error);
+			res.statusCode = formatError.status;
 			return {
 				props: {
-					error: transformError(fetchResult.error),
+					error: formatError,
 				},
 			};
 		}


### PR DESCRIPTION
### **User description**
#124


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Added comprehensive Jest tests for the `getServerSideProps` function, covering both normal and error scenarios.
- Enhanced error handling in `getServerSideProps` by utilizing the `transformError` function to format errors and set status codes appropriately.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.tsx</strong><dd><code>Add Jest tests for getServerSideProps function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/articles/[id]/_server/index.test.tsx

<li>Added Jest tests for <code>getServerSideProps</code>.<br> <li> Tested normal case for successful data retrieval.<br> <li> Tested error cases for invalid parameters and fetch errors.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/156/files#diff-f9913c81fa8938ca5b1923afea7517dbd12294df9320783c7f95223bef206d53">+126/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Enhance error handling in getServerSideProps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/articles/[id]/_server/index.tsx

<li>Enhanced error handling by using <code>transformError</code>.<br> <li> Updated status code setting with formatted error.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/156/files#diff-83e06fcd5335b743d36715824e3134b7aec45fce529e633660807ad7b13441db">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

