### PR TITLE
CSRエラーの画面設計と実装 

### DIFF
--- a/src/core/usecases/member/useResignMember.command.test.ts
+++ b/src/core/usecases/member/useResignMember.command.test.ts
@@ -7,18 +7,20 @@ import {
 } from "@/core/repositories/member/members.repository";
 
 import { outputErrorLog } from "@/error/outputErrorLog";
-import { useNotification } from "../../../error/hooks/useNotification";
+import { useErrorNotificationContext } from "@/feature/error/banner/ErrorNotificationContext";
 import { useResignMember } from "./useResignMember.command";
 
 jest.mock("@/core/repositories/member/members.repository");
-jest.mock("@/error/hooks/useNotification");
 jest.mock("@/error/outputErrorLog");
+jest.mock("@/feature/error/banner/ErrorNotificationContext");
 
 describe(useResignMember, () => {
-	const mockSetError = jest.fn();
-	toMock(useNotification).mockImplementation(() => {
+	const mockNotify = jest.fn();
+	toMock(useErrorNotificationContext).mockImplementation(() => {
 		return {
-			notify: mockSetError,
+			notify: mockNotify,
+			items: [],
+			clear: () => {},
 		};
 	});
 	const mockOutputErrorLog = jest.fn();
@@ -47,7 +49,7 @@ describe(useResignMember, () => {
 			await waitFor(async () => {
 				expect(await result.current(props)).toEqual(expected);
 			});
-			expect(mockSetError).not.toHaveBeenCalled();
+			expect(mockNotify).not.toHaveBeenCalled();
 			expect(mockOutputErrorLog).not.toHaveBeenCalled();
 		});
 	});
@@ -73,7 +75,7 @@ describe(useResignMember, () => {
 			await waitFor(async () => {
 				expect(await result.current(props)).toEqual(expected);
 			});
-			expect(mockSetError).toHaveBeenCalled();
+			expect(mockNotify).toHaveBeenCalled();
 			expect(mockOutputErrorLog).toHaveBeenCalled();
 		});
 	});

--- a/src/core/usecases/member/useResignMember.command.ts
+++ b/src/core/usecases/member/useResignMember.command.ts
@@ -4,7 +4,7 @@ import {
 	useUpdateMemberStatus,
 } from "@/core/repositories/member/members.repository";
 import { outputErrorLog } from "@/error/outputErrorLog";
-import { useNotification } from "../../../error/hooks/useNotification";
+import { useErrorNotificationContext } from "@/feature/error/banner/ErrorNotificationContext";
 
 type Props = {
 	reasonType: string;
@@ -18,7 +18,7 @@ type UseResignMemberReturnType = {
 
 export const useResignMember = () => {
 	const mutate = useUpdateMemberStatus();
-	const { notify } = useNotification();
+	const { notify } = useErrorNotificationContext();
 
 	return async (props: Props): Promise<UseResignMemberReturnType> => {
 		const activityInput: UpdateMemberStatusInputType = {

--- a/src/error/const.ts
+++ b/src/error/const.ts
@@ -4,8 +4,8 @@ export type RuntimeError = {
 };
 
 export type AppErrorMessage = {
-	title?: string;
-	message?: string;
+	title: string;
+	message: string;
 	myErrorCode: string;
 	level: "fatal" | "error" | "warning" | "info" | "debug";
 	// runtime error

--- a/src/error/hooks/useNotification.tsx
+++ b/src/error/hooks/useNotification.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from "react";
 import type { AppErrorMessage } from "../const";
 
+// TODO: contextにする
 export const useNotification = () => {
 	const [error, notify] = useState<AppErrorMessage | null>(null);
 
 	useEffect(() => {
 		if (error) {
 			// 一旦alertでエラーを表示している
-			window.alert(error);
+			// window.alert(error);
+			// TODO: バナー領域にエラーメッセージを表示する
 			notify(null);
 		}
 	}, [error]);

--- a/src/feature/error/banner/ErrorBanner.tsx
+++ b/src/feature/error/banner/ErrorBanner.tsx
@@ -1,0 +1,21 @@
+import { useErrorNotificationContext } from "./ErrorNotificationContext";
+
+export const ErrorBanner = () => {
+	const { items } = useErrorNotificationContext();
+
+	if (items.length === 0) {
+		return null;
+	}
+	return (
+		<div data-testid="error-banner">
+			{items.map((item) => (
+				<div key={item.myErrorCode}>
+					<p>
+						エラーコード:<span>{item.myErrorCode}</span>
+					</p>
+					<p>{item.message}</p>
+				</div>
+			))}
+		</div>
+	);
+};

--- a/src/feature/error/banner/ErrorBanner.tsx
+++ b/src/feature/error/banner/ErrorBanner.tsx
@@ -9,7 +9,7 @@ export const ErrorBanner = () => {
 	return (
 		<div data-testid="error-banner">
 			{items.map((item) => (
-				<div key={item.myErrorCode}>
+				<div key={item.myErrorCode} style={{ color: "red" }}>
 					<p>
 						エラーコード:<span>{item.myErrorCode}</span>
 					</p>

--- a/src/feature/error/banner/ErrorNotificationContext.tsx
+++ b/src/feature/error/banner/ErrorNotificationContext.tsx
@@ -1,0 +1,73 @@
+import type { AppErrorMessage } from "@/error/const";
+import {
+	type FC,
+	type PropsWithChildren,
+	createContext,
+	useContext,
+	useState,
+} from "react";
+
+type NotificationItem = {
+	message: string;
+	myErrorCode: string;
+};
+
+type ErrorNotificationStore = {
+	items: Readonly<NotificationItem[]>;
+	notify: (appErrorMessage: AppErrorMessage) => void;
+	clear: () => void;
+};
+
+const initialState: ErrorNotificationStore = {
+	items: [],
+	notify: () => {},
+	clear: () => {},
+};
+
+const useErrorNotification = (): ErrorNotificationStore => {
+	const [items, setItems] = useState<NotificationItem[]>([]);
+
+	const notify = (appErrorMessage: AppErrorMessage) => {
+		const item = {
+			message: appErrorMessage.message,
+			myErrorCode: appErrorMessage.myErrorCode,
+		};
+		setItems([item]);
+	};
+
+	const clear = () => {
+		if (items.length >= 1) {
+			setItems([]);
+		}
+	};
+
+	return {
+		items,
+		notify,
+		clear,
+	};
+};
+
+const ErrorNotificationContext =
+	createContext<ErrorNotificationStore>(initialState);
+
+type Props = {
+	customId: string;
+};
+
+export const ErrorNotificationProvider: FC<PropsWithChildren<Props>> = ({
+	customId,
+	children,
+}) => {
+	return (
+		// TODO: 要確認(ページ遷移時にDOMの初期化を行うため、id属性を設定している)
+		<div key={customId}>
+			<ErrorNotificationContext.Provider value={useErrorNotification()}>
+				{children}
+			</ErrorNotificationContext.Provider>
+		</div>
+	);
+};
+
+export const useErrorNotificationContext = () =>
+	useContext(ErrorNotificationContext);

--- a/src/feature/mypage/resignMember/confirm/index.tsx
+++ b/src/feature/mypage/resignMember/confirm/index.tsx
@@ -10,7 +10,11 @@ import {
 import { getCache, removeCache } from "@/utils/cache";
 import { sessionKeys } from "@/utils/cache/type";
 
+import { ErrorBanner } from "../../../error/banner/ErrorBanner";
+import { ErrorNotificationProvider } from "../../../error/banner/ErrorNotificationContext";
 import { ErrorBoundary as ConfirmErrorBoundary } from "./errorBoundary";
+
+const templateId = "mypage-resign-member-confirm";
 
 const Template: FC = () => {
 	const router = useRouter();
@@ -59,7 +63,9 @@ const Template: FC = () => {
 	}, []);
 
 	return (
-		<div data-testid={"mypage-resign-member-confirm"}>
+		<div data-testid={templateId}>
+			<ErrorBanner />
+
 			<form
 				onSubmit={handleSubmit((data, event) => submitHandler(data, event))}
 			>
@@ -104,8 +110,10 @@ const Template: FC = () => {
 
 export default function IndexTemplate() {
 	return (
-		<ConfirmErrorBoundary>
-			<Template />
-		</ConfirmErrorBoundary>
+		<ErrorNotificationProvider customId={templateId}>
+			<ConfirmErrorBoundary>
+				<Template />
+			</ConfirmErrorBoundary>
+		</ErrorNotificationProvider>
 	);
 }

--- a/src/pages/_provider/_appApollo.provider.tsx
+++ b/src/pages/_provider/_appApollo.provider.tsx
@@ -18,9 +18,9 @@ export const AppApolloProvider: FC<{
 			onError(({ operation, graphQLErrors, networkError, forward }) => {
 				if (graphQLErrors) {
 					graphQLErrors.map(({ message, extensions }) => {
-						console.log(
-							`[GraphQL error]: Message: ${message}, Code: ${extensions.code}, Path: ${extensions.path}`,
-						);
+						// console.log(
+						// 	`[GraphQL error]: Message: ${message}, Code: ${extensions.code}, Path: ${extensions.path}`,
+						// );
 						switch (extensions.code) {
 							// session系の処理のみ必要。
 							case "invalid-jwt": {
@@ -39,14 +39,14 @@ export const AppApolloProvider: FC<{
 								return forward(operation);
 							}
 							default:
-								// default case
-								console.log(extensions.code);
+							// default case
+							// console.log(extensions.code);
 						}
 					});
 				}
-				if (networkError) {
-					console.log(`TODO: [Network error]: ${networkError}`);
-				}
+				// if (networkError) {
+				// console.log(`TODO: [Network error]: ${networkError}`);
+				// }
 			}),
 		[],
 	);


### PR DESCRIPTION
### **User description**
#125


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- 新しいエラーバナーコンポーネントを実装し、エラーメッセージを表示する機能を追加しました。
- `useNotification`を`useErrorNotificationContext`に置き換え、エラーハンドリングを改善しました。
- `AppErrorMessage`型の`title`と`message`フィールドを必須に変更しました。
- 退会確認ページにエラーハンドリングコンポーネントを統合し、エラー発生時の表示をテストしました。
- GraphQLおよびネットワークエラーのコンソールログを抑制しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>useResignMember.command.test.ts</strong><dd><code>Update error notification handling in member resignation tests</code></dd></summary>
<hr>

src/core/usecases/member/useResignMember.command.test.ts

<li>Replaced <code>useNotification</code> with <code>useErrorNotificationContext</code>.<br> <li> Updated mock function names from <code>mockSetError</code> to <code>mockNotify</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-05e86635509a34d57db500f57ead5ade44986a3e28ec9e9ae78bb90db3cc52c4">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useResignMember.command.ts</strong><dd><code>Use new error notification context in member resignation command</code></dd></summary>
<hr>

src/core/usecases/member/useResignMember.command.ts

- Replaced `useNotification` with `useErrorNotificationContext`.



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-379fccc2f62d9c192752e966c3b068ae0828a916ba7fe12febc4268a5b12c8cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>const.ts</strong><dd><code>Update AppErrorMessage type to require title and message</code>&nbsp; </dd></summary>
<hr>

src/error/const.ts

- Made `title` and `message` fields in `AppErrorMessage` mandatory.



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-9c892428d05c8d09700528eb7d96086942c702ea7c7f6a33ea6bb79d0525c755">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useNotification.tsx</strong><dd><code>Modify error notification to prepare for banner display</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/error/hooks/useNotification.tsx

<li>Commented out alert display for errors.<br> <li> Added TODO for displaying error messages in a banner.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-c377dcefd8e029f48022b21261c58d359d66bc2d97eaa586f6794331c0bd3f00">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ErrorBanner.tsx</strong><dd><code>Implement ErrorBanner component for error message display</code></dd></summary>
<hr>

src/feature/error/banner/ErrorBanner.tsx

<li>Implemented a new <code>ErrorBanner</code> component to display error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-e354b57661e9430deea2b412c75f11a36299832e8fd821eac5166fc9777167fe">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ErrorNotificationContext.tsx</strong><dd><code>Create ErrorNotificationContext for managing error notifications</code></dd></summary>
<hr>

src/feature/error/banner/ErrorNotificationContext.tsx

<li>Created <code>ErrorNotificationContext</code> for managing error notifications.<br> <li> Provided methods to notify and clear error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-ca9679ff354e36ef2c3acaedd5ed5573e7092773fc397bd266e6fab9c9555b9a">+73/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Integrate error handling components into resignation confirmation</code></dd></summary>
<hr>

src/feature/mypage/resignMember/confirm/index.tsx

<li>Integrated <code>ErrorBanner</code> and <code>ErrorNotificationProvider</code> into the <br>template.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-6cfd1c36bf6079aa2f5f12239c1f5bda04dfba436c7f0db3b7f107ec1ce5c3c8">+12/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_appApollo.provider.tsx</strong><dd><code>Suppress console logs for GraphQL and network errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/_provider/_appApollo.provider.tsx

- Commented out console logs for GraphQL and network errors.



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-0fc467d440216cd400c9cbad4fbc13890649e19a20584bb7973c5b0d26f8ff91">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.tsx</strong><dd><code>Add tests for error handling in resignation confirmation</code>&nbsp; </dd></summary>
<hr>

src/feature/mypage/resignMember/confirm/index.test.tsx

<li>Added test for error display on form submission.<br> <li> Mocked <code>outputErrorLog</code> for error handling.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/157/files#diff-da4ce5c416f85036ab319ba60ffa545e3bf987f3eb8b65b2617da5d991a31032">+21/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

