### PR TITLE
refactor: dialogコンポーネントを切り出す

### DIFF
--- a/src/feature/admin/allMembers/index/dialog/BanDialog.tsx
+++ b/src/feature/admin/allMembers/index/dialog/BanDialog.tsx
@@ -1,0 +1,73 @@
+import { Button, Dialog } from "@/components";
+import { DialogBody } from "@/components/dialog/Dialog";
+import type { ActiveMember } from "@/core/domains/member/activeMember";
+import type { PendingActivationMember } from "@/core/domains/member/pendingActivationMember";
+import { type BaseSyntheticEvent, forwardRef } from "react";
+import {
+	type BanMemberSchema,
+	useBanMemberForm,
+} from "../form/useBanMemberForm";
+import type { OnSubmitBan } from "../table/type";
+
+type props = {
+	member: ActiveMember | PendingActivationMember;
+	onSubmitBan: OnSubmitBan<ActiveMember | PendingActivationMember>;
+	onClose: () => void;
+};
+
+export const BanDialog = forwardRef<HTMLDialogElement, props>(function dialog(
+	{ member, onSubmitBan: onSubmit, onClose },
+	ref,
+) {
+	const {
+		handleSubmit,
+		register,
+		formState: { isSubmitting, isValid, errors },
+		reset,
+		banMemberLabels,
+	} = useBanMemberForm();
+
+	const onSubmitBan = (data: BanMemberSchema, event?: BaseSyntheticEvent) => {
+		event?.preventDefault();
+		reset();
+		onSubmit(member, data);
+	};
+
+	return (
+		<Dialog ref={ref}>
+			<DialogBody>
+				{/* bodytitle */}
+				<h2
+					className="text-std-24B-5 desktop:text-std-28B-5"
+					id="example-heading1"
+				>
+					BAN
+				</h2>
+				{/* body */}
+				<p className="text-std-16N-7">ダイアログの補助テキストが入ります。</p>
+
+				{/* form */}
+				<div className="mt-2 flex w-full max-w-xs flex-col gap-4 desktop:mt-6">
+					{/* action */}
+					<form onSubmit={handleSubmit(onSubmitBan)}>
+						<div>
+							<label htmlFor="reason">{banMemberLabels.reason}</label>
+							<textarea id="reason" {...register("reason")} />
+							{errors.reason?.message && <p>{errors.reason.message}</p>}
+						</div>
+						<Button
+							size="lg"
+							variant="primary"
+							disabled={!isValid || isSubmitting}
+						>
+							送信
+						</Button>
+						<Button onClick={onClose} size="lg" variant="tertiary">
+							キャンセル
+						</Button>
+					</form>
+				</div>
+			</DialogBody>
+		</Dialog>
+	);
+});

--- a/src/feature/admin/allMembers/index/dialog/DisableDialog.tsx
+++ b/src/feature/admin/allMembers/index/dialog/DisableDialog.tsx
@@ -1,0 +1,47 @@
+import { Button, Dialog } from "@/components";
+import { DialogBody } from "@/components/dialog/Dialog";
+import type { ActiveMember } from "@/core/domains/member/activeMember";
+import { forwardRef } from "react";
+import type { OnSubmitDisable } from "../table/type";
+
+type props = {
+	member: ActiveMember;
+	onSubmitDisable: OnSubmitDisable<ActiveMember>;
+	onClose: () => void;
+};
+
+export const DisableDialog = forwardRef<HTMLDialogElement, props>(
+	function dialog({ member, onSubmitDisable, onClose }, ref) {
+		return (
+			<Dialog ref={ref}>
+				<DialogBody>
+					{/* bodytitle */}
+					<h2
+						className="text-std-24B-5 desktop:text-std-28B-5"
+						id="example-heading1"
+					>
+						Disable status is:{member.status}
+					</h2>
+					{/* body */}
+					<p className="text-std-16N-7">
+						ダイアログの補助テキストが入ります。ダイアログの補助テキストが入ります。
+					</p>
+					{/* form */}
+					<div className="mt-2 flex w-full max-w-xs flex-col gap-4 desktop:mt-6">
+						{/* action */}
+						<Button
+							onClick={onSubmitDisable(member)}
+							size="lg"
+							variant="primary"
+						>
+							無効化する
+						</Button>
+						<Button onClick={onClose} size="lg" variant="tertiary">
+							キャンセル
+						</Button>
+					</div>
+				</DialogBody>
+			</Dialog>
+		);
+	},
+);

--- a/src/feature/admin/allMembers/index/table/MemberTableRow.tsx
+++ b/src/feature/admin/allMembers/index/table/MemberTableRow.tsx
@@ -5,15 +5,17 @@ import { DialogBody } from "@/components/dialog/Dialog";
 import type { ActiveMember } from "@/core/domains/member/activeMember";
 import type { PendingActivationMember } from "@/core/domains/member/pendingActivationMember";
 import { type BaseSyntheticEvent, type FC, useRef } from "react";
-import {
-	type BanMemberSchema,
-	useBanMemberForm,
-} from "../form/useBanMemberForm";
+import { isValid } from "zod";
+import { BanDialog } from "../dialog/BanDialog";
+import { DisableDialog } from "../dialog/DisableDialog";
+import type { BanMemberSchema } from "../form/useBanMemberForm";
 import { ActiveMemberRow } from "./ActiveMemberRow";
 import { PendingActivationMemberRow } from "./PendingActivationMemberRow";
 import {
 	type OnClickBan,
 	type OnClickDisable,
+	type OnSubmitBan,
+	type OnSubmitDisable,
 	type OnSubmitStatusChange,
 	eventTypes,
 } from "./type";
@@ -39,47 +41,29 @@ export const MemberTableRow: FC<Prop> = ({ member, onSubmit }) => {
 		disableDialogRef.current?.showModal();
 	};
 
-	const {
-		handleSubmit,
-		register,
-		formState: { isSubmitting, isValid, errors },
-		banMemberLabels,
-		reset,
-	} = useBanMemberForm();
-
-	const onSubmitBan = <K extends ActiveMember | PendingActivationMember>(
-		member: K,
+	const onSubmitBan: OnSubmitBan<ActiveMember | PendingActivationMember> = (
+		member,
+		data,
 	) => {
-		return (data: BanMemberSchema, event?: BaseSyntheticEvent) => {
-			event?.preventDefault?.();
-			console.log("onSubmitBan");
+		ref.current?.close();
 
-			// close dialog
-			ref.current?.close();
-			// reset form state
-			reset();
-
-			// call mutation
-			onSubmit({
-				type: eventTypes.onClickBan,
-				detail: {
-					member,
-					reason: data.reason,
-				},
-			});
-		};
+		// call mutation
+		onSubmit({
+			type: eventTypes.onClickBan,
+			detail: {
+				member,
+				reason: data.reason,
+			},
+		});
 	};
 
-	const onSubmitDisable = <K extends ActiveMember>(member: K) => {
-		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-		return (e: any) => {
-			e.preventDefault();
+	const onSubmitDisable: OnSubmitDisable<ActiveMember> = (member) => {
+		return () => {
 			console.log("onSubmitDisable");
 
 			// close dialog
 			disableDialogRef.current?.close();
 			// reset form state
-			reset();
 
 			// call mutation
 			onSubmit({
@@ -98,128 +82,34 @@ export const MemberTableRow: FC<Prop> = ({ member, onSubmit }) => {
 						onClickBan={onClickBan}
 						onClickDisable={onClickDisable}
 					/>
-					{/* TODO: コンポーネントのリファクタをしたい */}
-					<Dialog ref={ref}>
-						<DialogBody>
-							<h2
-								className="text-std-24B-5 desktop:text-std-28B-5"
-								id="example-heading1"
-							>
-								BAN
-							</h2>
-							<p className="text-std-16N-7">
-								ダイアログの補助テキストが入ります。
-							</p>
-							<div className="mt-2 flex w-full max-w-xs flex-col gap-4 desktop:mt-6">
-								<form onSubmit={handleSubmit(onSubmitBan(member))}>
-									<div>
-										<label htmlFor="reason">{banMemberLabels.reason}</label>
-										<textarea id="reason" {...register("reason")} />
-										{errors.reason?.message && <p>{errors.reason.message}</p>}
-									</div>
-
-									<Button
-										size="lg"
-										variant="primary"
-										disabled={!isValid || isSubmitting}
-									>
-										送信
-									</Button>
-									<Button
-										onClick={(e) => {
-											e.preventDefault();
-											reset();
-											ref.current?.close();
-										}}
-										size="lg"
-										variant="tertiary"
-									>
-										キャンセル
-									</Button>
-								</form>
-							</div>
-						</DialogBody>
-					</Dialog>
-					{/* TODO: コンポーネントのリファクタをしたい */}
-					<Dialog ref={disableDialogRef}>
-						<DialogBody>
-							<h2
-								className="text-std-24B-5 desktop:text-std-28B-5"
-								id="example-heading1"
-							>
-								Disable
-							</h2>
-							<p className="text-std-16N-7">
-								ダイアログの補助テキストが入ります。ダイアログの補助テキストが入ります。
-							</p>
-							<div className="mt-2 flex w-full max-w-xs flex-col gap-4 desktop:mt-6">
-								<Button
-									onClick={onSubmitDisable(member)}
-									size="lg"
-									variant="primary"
-								>
-									無効化する
-								</Button>
-								<Button
-									onClick={() => {
-										disableDialogRef.current?.close();
-									}}
-									size="lg"
-									variant="tertiary"
-								>
-									キャンセル
-								</Button>
-							</div>
-						</DialogBody>
-					</Dialog>
+					<BanDialog
+						member={member}
+						onSubmitBan={onSubmitBan}
+						onClose={() => {
+							ref.current?.close();
+						}}
+					/>
+					<DisableDialog
+						ref={disableDialogRef}
+						member={member}
+						onSubmitDisable={onSubmitDisable}
+						onClose={() => {
+							disableDialogRef.current?.close();
+						}}
+					/>
 				</>
 			);
 		case "pendingActivation":
 			return (
 				<>
 					<PendingActivationMemberRow member={member} onClickBan={onClickBan} />
-					{/* TODO: コンポーネントのリファクタをしたい */}
-					<Dialog ref={ref}>
-						<DialogBody>
-							<h2
-								className="text-std-24B-5 desktop:text-std-28B-5"
-								id="example-heading1"
-							>
-								BAN
-							</h2>
-							<p className="text-std-16N-7">
-								ダイアログの補助テキストが入ります。
-							</p>
-							<div className="mt-2 flex w-full max-w-xs flex-col gap-4 desktop:mt-6">
-								<form onSubmit={handleSubmit(onSubmitBan(member))}>
-									<div>
-										<label htmlFor="reason">{banMemberLabels.reason}</label>
-										<textarea id="reason" {...register("reason")} />
-										{errors.reason?.message && <p>{errors.reason.message}</p>}
-									</div>
-
-									<Button
-										size="lg"
-										variant="primary"
-										disabled={!isValid || isSubmitting}
-									>
-										送信
-									</Button>
-									<Button
-										onClick={(e) => {
-											e.preventDefault();
-											reset();
-											ref.current?.close();
-										}}
-										size="lg"
-										variant="tertiary"
-									>
-										キャンセル
-									</Button>
-								</form>
-							</div>
-						</DialogBody>
-					</Dialog>
+					<BanDialog
+						member={member}
+						onSubmitBan={onSubmitBan}
+						onClose={() => {
+							ref.current?.close();
+						}}
+					/>
 				</>
 			);
 	}

--- a/src/feature/admin/allMembers/index/table/type.ts
+++ b/src/feature/admin/allMembers/index/table/type.ts
@@ -1,5 +1,7 @@
 import type { ActiveMember } from "@/core/domains/member/activeMember";
 import type { PendingActivationMember } from "@/core/domains/member/pendingActivationMember";
+import type { BaseSyntheticEvent } from "react";
+import type { BanMemberSchema } from "../form/useBanMemberForm";
 
 //
 // Payload
@@ -47,3 +49,10 @@ export type OnClickBan<K extends ActiveMember | PendingActivationMember> = (
 ) => void;
 
 export type OnClickDisable<K extends ActiveMember> = (member: K) => void;
+
+export type OnSubmitDisable<K extends ActiveMember> = (member: K) => () => void;
+
+export type OnSubmitBan<K extends ActiveMember | PendingActivationMember> = (
+	member: K,
+	data: BanMemberSchema,
+) => void;


### PR DESCRIPTION
### **User description**
#186


___

### **PR Type**
enhancement


___

### **Description**
- `BanDialog`と`DisableDialog`という新しいコンポーネントを追加し、メンバーのBANおよび無効化処理を分離しました。
- `MemberTableRow`でこれらの新しいダイアログコンポーネントを使用し、コードの可読性と再利用性を向上させました。
- 型定義を更新し、新しいダイアログコンポーネントに対応しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BanDialog.tsx</strong><dd><code>`BanDialog`コンポーネントの追加とフォーム実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/feature/admin/allMembers/index/dialog/BanDialog.tsx

<li>新しい<code>BanDialog</code>コンポーネントを追加<br> <li> <code>useBanMemberForm</code>を利用してフォームを実装<br> <li> <code>onSubmitBan</code>関数でデータ送信を処理<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/194/files#diff-71a3a2eaa9e1e3217abececcd4ba2b1a880ca5e6146c985b296d4d6e3c1bcd78">+73/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DisableDialog.tsx</strong><dd><code>`DisableDialog`コンポーネントの追加と無効化処理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/feature/admin/allMembers/index/dialog/DisableDialog.tsx

<li>新しい<code>DisableDialog</code>コンポーネントを追加<br> <li> メンバーの無効化ステータスを表示<br> <li> <code>onSubmitDisable</code>関数で無効化処理を実装<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/194/files#diff-a995f21305bd1f3b3bcd4b6905c31a6f8724dad27b42617ce9776b97a20f9293">+47/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>MemberTableRow.tsx</strong><dd><code>ダイアログコンポーネントの統合とロジックのリファクタリング</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/feature/admin/allMembers/index/table/MemberTableRow.tsx

<li><code>BanDialog</code>と<code>DisableDialog</code>コンポーネントを使用<br> <li> <code>onSubmitBan</code>と<code>onSubmitDisable</code>関数をリファクタリング<br> <li> ダイアログの表示ロジックを簡素化<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/194/files#diff-40223f1b785d285128f2045e6746ee6b3cc16d9b6e99eead9f458ef62d80a9c0">+42/-152</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>type.ts</strong><dd><code>新しいダイアログ用の型定義の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/feature/admin/allMembers/index/table/type.ts

- `OnSubmitBan`と`OnSubmitDisable`型を追加
- 型定義を更新して新しいダイアログコンポーネントに対応



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/194/files#diff-620553a49c35c592e78e1925e259af2cb5a00a4f49d6dc1f5e79b63652de6989">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

