### PR TITLE
fix: image of debian:bullseye-slim

### DIFF
--- a/functions/Dockerfile
+++ b/functions/Dockerfile
@@ -1,8 +1,10 @@
-FROM ubuntu:22.04
+FROM debian:bullseye-slim
 
 RUN apt update && \
-apt install -y curl openjdk-17-jdk && \
+apt install -y --no-install-recommends curl openjdk-17-jdk && \
 curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-apt install -y nodejs
+apt install -y --no-install-recommends nodejs - && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g firebase-tools

--- a/functions/Dockerfile
+++ b/functions/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 RUN apt update && \
 apt install -y --no-install-recommends curl openjdk-17-jdk && \
 curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-apt install -y --no-install-recommends nodejs - && \
+apt install -y --no-install-recommends nodejs && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### **User description**
#207


___

### **PR Type**
enhancement


___

### **Description**
- Dockerfileのベースイメージを`debian:bullseye-slim`に変更し、イメージサイズを最適化。
- `apt install`コマンドに`--no-install-recommends`オプションを追加し、不要なパッケージのインストールを回避。
- `apt-get clean`と`rm -rf /var/lib/apt/lists/*`を追加して、キャッシュをクリアし、イメージサイズを削減。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Dockerfileのベースイメージとインストール方法の最適化</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

functions/Dockerfile

<li>ベースイメージを<code>ubuntu:22.04</code>から<code>debian:bullseye-slim</code>に変更<br> <li> 不要なパッケージのインストールを避けるため<code>--no-install-recommends</code>オプションを追加<br> <li> <code>apt-get clean</code>と<code>rm -rf /var/lib/apt/lists/*</code>でイメージサイズを最適化<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/208/files#diff-88224d978d16d31ce1a8cc4ceeb3aa8e4629df630b8821992f2e5b64f81b6c0b">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

