### PR TITLE
ローカルホストでVScode dubuggerの動作確認する

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,15 +14,13 @@
     //   "url": "http://localhost:3000"
     // },
     {
-      "name": "Next.js: debug full stack",
-      "type": "node-terminal",
-      "request": "launch",
-      "command": "npm run dev",
-      "serverReadyAction": {
-        "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s",
-        "action": "debugWithChrome"
-      }
+      "type": "node",
+      "request": "attach",
+      "name": "Next: server",
+      "port": 9230,
+      "address": "localhost",
+      "localRoot": "${workspaceFolder}/app",
+      "remoteRoot": "/app" // Docker内のアプリのディレクトリ
     }
   ]
 }

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "node": "^v18.19.0"
   },
   "scripts": {
-    "debug": "NODE_OPTIONS='--inspect' next src",
+    "debug": "NODE_OPTIONS='--inspect' next dev",
     "dev": "NEXT_PUBLIC_API_MOCKING=enabled next dev",
     "dev:all": "npm-run-all -p dev db:start fn:dev fn:watch",
     "build": "next build",

--- a/app/src/pages/articles/[id]/_server/index.tsx
+++ b/app/src/pages/articles/[id]/_server/index.tsx
@@ -10,6 +10,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 }): Promise<{
 	props: PagePropsType;
 }> => {
+	debugger
 	try {
 		// 1. 例: パラメータのバリデーション
 		const result = validateParams(params);

--- a/app/src/pages/articles/[id]/_server/index.tsx
+++ b/app/src/pages/articles/[id]/_server/index.tsx
@@ -10,7 +10,6 @@ export const getServerSideProps: GetServerSideProps = async ({
 }): Promise<{
 	props: PagePropsType;
 }> => {
-	debugger
 	try {
 		// 1. 例: パラメータのバリデーション
 		const result = validateParams(params);


### PR DESCRIPTION
### **User description**
#209


___

### **PR Type**
enhancement


___

### **Description**
- VSCodeのデバッグ設定を更新し、Node.jsプロセスにアタッチする新しい設定を追加しました。これにより、ローカルホストのポート9230に接続できます。
- `package.json`の`debug`スクリプトを`next dev`を使用するように変更しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.json</strong><dd><code>Update VSCode launch configuration for Node.js debugging</code>&nbsp; </dd></summary>
<hr>

.vscode/launch.json

<li>Removed the full stack debug configuration.<br> <li> Added a new configuration for attaching to a Node.js process.<br> <li> Configured to attach to port 9230 on localhost.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/212/files#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update debug script in package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/package.json

- Modified the `debug` script to use `next dev`.



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/212/files#diff-012b982f97a0d326aeec58dd3b789484b05a944d609afe1b8ed5e299fc485f61">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

