### PR TITLE
WIP Fix container swc

### DIFF
--- a/.github/workflows/deploy-to-vercel.yml
+++ b/.github/workflows/deploy-to-vercel.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@latest --ignore-scripts
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@latest --ignore-scripts
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-to-vercel.yml
+++ b/.github/workflows/deploy-to-vercel.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Unit test
         run: npm run test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: storybook build
         run: npm run storybook:build

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Unit test
         run: npm run test

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -10,7 +10,13 @@ COPY app .
 # 依存関係をインストール
 RUN npm install -g npm@latest
 
-RUN npm ci
+RUN npm ci --ignore-scripts
+
+# node_modulesディレクトリのアクセス権を変更
+RUN chmod -R a+w node_modules
+
+# TODO: post_installスクリプトを実行する(空振りするため一旦コメントアウト中)
+# RUN sed -E -i 's/NODE_OPTIONS.*nodeDebugType.*/NODE_OPTIONS = `${NODE_OPTIONS} --${nodeDebugType}=0.0.0.0:9230`;/' node_modules/next/dist/cli/next-dev.js
 
 # シェルを使用して複数コマンドを実行する npm run dev
 CMD ["npm", "run", "dev"]

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nextjs-tdd-template",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "^3.9.11",
         "@digital-go-jp/tailwind-theme-plugin": "^0.1.15",
@@ -5280,14 +5281,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.6.tgz",
-      "integrity": "sha512-bs5DFKV+08EjWrl8EB+KKqev1ZTNONH1vFCaHh911aaB362NnP32UDTbE9VQhyiAgbFqJsfDkSxFERNDDb3j0g=="
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.12.tgz",
+      "integrity": "sha512-3fP29GIetdwVIfIRyLKM7KrvJaqepv+6pVodEbx0P5CaMLYBtx+7eEg8JYO5L9sveJO87z9eCReceZLi0hxO1Q=="
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.6.tgz",
-      "integrity": "sha512-BtJZb+hYXGaVJJivpnDoi3JFVn80SHKCiiRUW3kk1SY6UCUy5dWFFSbh+tGi5lHAughzeduMyxbLt3pspvXNSg==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.12.tgz",
+      "integrity": "sha512-crHJ9UoinXeFbHYNok6VZqjKnd8rTd7K3Z2zpyzF1ch7vVNKmhjv/V7EHxep3ILoN8JB9AdRn/EtVVyG9AkCXw==",
       "cpu": [
         "arm64"
       ],
@@ -5300,9 +5301,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.6.tgz",
-      "integrity": "sha512-ZHRbGpH6KHarzm6qEeXKSElSXh8dS2DtDPjQt3IMwY8QVk7GbdDYjvV4NgSnDA9huGpGgnyy3tH8i5yHCqVkiQ==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.12.tgz",
+      "integrity": "sha512-JbEaGbWq18BuNBO+lCtKfxl563Uw9oy2TodnN2ioX00u7V1uzrsSUcg3Ep9ce+P0Z9es+JmsvL2/rLphz+Frcw==",
       "cpu": [
         "x64"
       ],
@@ -5315,9 +5316,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.6.tgz",
-      "integrity": "sha512-O4HqUEe3ZvKshXHcDUXn1OybN4cSZg7ZdwHJMGCXSUEVUqGTJVsOh17smqilIjooP/sIJksgl+1kcf2IWMZWHg==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.12.tgz",
+      "integrity": "sha512-qBy7OiXOqZrdp88QEl2H4fWalMGnSCrr1agT/AVDndlyw2YJQA89f3ttR/AkEIP9EkBXXeGl6cC72/EZT5r6rw==",
       "cpu": [
         "arm64"
       ],
@@ -5330,9 +5331,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.6.tgz",
-      "integrity": "sha512-xUcdhr2hfalG8RDDGSFxQ75yOG894UlmFS4K2M0jLrUhauRBGOtUOxoDVwiIIuZQwZ3Y5hDsazNjdYGB0cQ9yQ==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.12.tgz",
+      "integrity": "sha512-EfD9L7o9biaQxjwP1uWXnk3vYZi64NVcKUN83hpVkKocB7ogJfyH2r7o1pPnMtir6gHZiGCeHKagJ0yrNSLNHw==",
       "cpu": [
         "arm64"
       ],
@@ -5345,9 +5346,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.6.tgz",
-      "integrity": "sha512-InosKxw8UMcA/wEib5n2QttwHSKHZHNSbGcMepBM0CTcNwpxWzX32KETmwbhKod3zrS8n1vJ+DuJKbL9ZAB0Ag==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.12.tgz",
+      "integrity": "sha512-iQ+n2pxklJew9IpE47hE/VgjmljlHqtcD5UhZVeHICTPbLyrgPehaKf2wLRNjYH75udroBNCgrSSVSVpAbNoYw==",
       "cpu": [
         "x64"
       ],
@@ -5360,9 +5361,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.6.tgz",
-      "integrity": "sha512-d4QXfJmt5pGJ7cG8qwxKSBnO5AXuKAFYxV7qyDRHnUNvY/dgDh+oX292gATpB2AAHgjdHd5ks1wXxIEj6muLUQ==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.12.tgz",
+      "integrity": "sha512-rFkUkNwcQ0ODn7cxvcVdpHlcOpYxMeyMfkJuzaT74xjAa5v4fxP4xDk5OoYmPi8QNLDs3UgZPMSBmpBuv9zKWA==",
       "cpu": [
         "x64"
       ],
@@ -5375,9 +5376,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.6.tgz",
-      "integrity": "sha512-AlgIhk4/G+PzOG1qdF1b05uKTMsuRatFlFzAi5G8RZ9h67CVSSuZSbqGHbJDlcV1tZPxq/d4G0q6qcHDKWf4aQ==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.12.tgz",
+      "integrity": "sha512-PQFYUvwtHs/u0K85SG4sAdDXYIPXpETf9mcEjWc0R4JmjgMKSDwIU/qfZdavtP6MPNiMjuKGXHCtyhR/M5zo8g==",
       "cpu": [
         "arm64"
       ],
@@ -5390,9 +5391,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.6.tgz",
-      "integrity": "sha512-hNukAxq7hu4o5/UjPp5jqoBEtrpCbOmnUqZSKNJG8GrUVzfq0ucdhQFVrHcLRMvQcwqqDh1a5AJN9ORnNDpgBQ==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.12.tgz",
+      "integrity": "sha512-FAj2hMlcbeCV546eU2tEv41dcJb4NeqFlSXU/xL/0ehXywHnNpaYajOUvn3P8wru5WyQe6cTZ8fvckj/2XN4Vw==",
       "cpu": [
         "ia32"
       ],
@@ -5405,9 +5406,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.6.tgz",
-      "integrity": "sha512-NANtw+ead1rSDK1jxmzq3TYkl03UNK2KHqUYf1nIhNci6NkeqBD4s1njSzYGIlSHxCK+wSaL8RXZm4v+NF/pMw==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.12.tgz",
+      "integrity": "sha512-yu8QvV53sBzoIVRHsxCHqeuS8jYq6Lrmdh0briivuh+Brsp6xjg80MAozUsBTAV9KNmY08KlX0KYTWz1lbPzEg==",
       "cpu": [
         "x64"
       ],
@@ -16312,11 +16313,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "14.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.6.tgz",
-      "integrity": "sha512-57Su7RqXs5CBKKKOagt8gPhMM3CpjgbeQhrtei2KLAA1vTNm7jfKS+uDARkSW8ZETUflDCBIsUKGSyQdRs4U4g==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.12.tgz",
+      "integrity": "sha512-cDOtUSIeoOvt1skKNihdExWMTybx3exnvbFbb9ecZDIxlvIbREQzt9A5Km3Zn3PfU+IFjyYGsHS+lN9VInAGKA==",
       "dependencies": {
-        "@next/env": "14.2.6",
+        "@next/env": "14.2.12",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -16331,15 +16332,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.6",
-        "@next/swc-darwin-x64": "14.2.6",
-        "@next/swc-linux-arm64-gnu": "14.2.6",
-        "@next/swc-linux-arm64-musl": "14.2.6",
-        "@next/swc-linux-x64-gnu": "14.2.6",
-        "@next/swc-linux-x64-musl": "14.2.6",
-        "@next/swc-win32-arm64-msvc": "14.2.6",
-        "@next/swc-win32-ia32-msvc": "14.2.6",
-        "@next/swc-win32-x64-msvc": "14.2.6"
+        "@next/swc-darwin-arm64": "14.2.12",
+        "@next/swc-darwin-x64": "14.2.12",
+        "@next/swc-linux-arm64-gnu": "14.2.12",
+        "@next/swc-linux-arm64-musl": "14.2.12",
+        "@next/swc-linux-x64-gnu": "14.2.12",
+        "@next/swc-linux-x64-musl": "14.2.12",
+        "@next/swc-win32-arm64-msvc": "14.2.12",
+        "@next/swc-win32-ia32-msvc": "14.2.12",
+        "@next/swc-win32-x64-msvc": "14.2.12"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "db:metadata": "npm run db:metadata --prefix ./db",
     "db:meta:export": "npm run db:meta:export --prefix ./db",
     "db:dump": "npm run db:dump --prefix ./db",
-    "patch:debug:port": "sed -E -i '' 's/NODE_OPTIONS.*nodeDebugType.*/NODE_OPTIONS = `${NODE_OPTIONS} --${nodeDebugType}=0.0.0.0:9230`;/' node_modules/next/dist/cli/next-dev.js"
+    "postinstall": "sed -E -i '' 's/NODE_OPTIONS.*nodeDebugType.*/NODE_OPTIONS = `${NODE_OPTIONS} --${nodeDebugType}=0.0.0.0:9230`;/' node_modules/next/dist/cli/next-dev.js"
   },
   "dependencies": {
     "@apollo/client": "^3.9.11",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
 
   app_dev:
     container_name: app_dev
+    user: "${UID}:${GID}"
+    platform: linux/arm64
     build:
       context: .
       dockerfile: ./app/Dockerfile

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -19,3 +19,6 @@ node_modules/
 .bin/
 .config/
 .data/
+
+# env
+.env*


### PR DESCRIPTION
## 事象
コンテナー内でnpm run devするとエラーになる
```
app_dev  | > nextjs-tdd-template@0.1.0 dev
app_dev  | > NEXT_PUBLIC_API_MOCKING=enabled NODE_OPTIONS='--inspect=0.0.0.0' next dev
app_dev  |
Debugger listening on ws://0.0.0.0:9229/ec878254-f105-4c97-b62f-0a3c11b81059
app_dev  | For help, see: https://nodejs.org/en/docs/inspector
app_dev  | Debugger listening on ws://0.0.0.0:9230/11be9245-ed81-4e34-bdfc-2436171ed10b
app_dev  | For help, see: https://nodejs.org/en/docs/inspector
app_dev  |    the --inspect option was detected, the Next.js router server should be inspected at port 0.
app_dev  |   ▲ Next.js 14.2.12
app_dev  |   - Local:        http://localhost:3000
app_dev  |   - Environments: .env.local
app_dev  |   - Experiments (use with caution):
app_dev  |     · instrumentationHook
app_dev  |
app_dev  |  ✓ Starting...
app_dev  |  ⚠ Attempted to load @next/swc-linux-arm64-gnu, but it was not installed
app_dev  |  ⚠ Attempted to load @next/swc-linux-arm64-musl, but it was not installed
app_dev  |  ⨯ Failed to load SWC binary for linux/arm64, see more info here: https://nextjs.org/docs/messages/failed-loading-swc
app_dev  |

app_dev exited with code 0
```

## ワークアラウンド
一旦、下記のコマンドを打つと回避できた。
```
docker compose run app_dev npm install --ignore-scripts
```

## 原因
linux/arm64でnpm iした場合、node_modules内のnextのswcがlinuxようになる
MacOSでnpm iした場合、node_modules内のnextのswcがMacOSようになる
→https://qiita.com/P-man_Brown/items/db1996bdee33ee667741


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Dockerfile has been updated to include `--ignore-scripts` in the `npm ci` command and to change permissions for the `node_modules` directory.
- The `post_install` script execution in the Dockerfile is commented out.
- The `package-lock.json` file has been updated to reflect new versions for several `@next` packages.
- The `package.json` file now uses a `postinstall` script instead of `patch:debug:port`.
- The `docker-compose.yml` file has been updated to include `user` and `platform` settings for the `app_dev` service.
- Documentation link in `next-env.d.ts` has been updated.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next-env.d.ts</strong><dd><code>Update TypeScript documentation link in comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/next-env.d.ts

- Updated URL in the comment to reflect new documentation link.



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/220/files#diff-1883ceff25d8c6c084b63bb095b7a6756d8708db6c3d358507180e178b9acef6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Modify Dockerfile for npm installation and permissions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Dockerfile

<li>Added <code>--ignore-scripts</code> to <code>npm ci</code> command.<br> <li> Changed permissions for <code>node_modules</code> directory.<br> <li> Commented out <code>post_install</code> script execution.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/220/files#diff-e0a276468ce17255f8b80e848af78bb956cc1795602398446a892114b6afc0b8">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Modify post-installation script in package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/package.json

- Replaced `patch:debug:port` script with `postinstall` script.



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/220/files#diff-012b982f97a0d326aeec58dd3b789484b05a944d609afe1b8ed5e299fc485f61">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update docker-compose for user and platform settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

- Added `user` and `platform` configurations for `app_dev` service.



</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/220/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Update package versions and add install script flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/package-lock.json

<li>Updated package versions for <code>@next/env</code>, <code>@next/swc-*</code>, and <code>next</code>.<br> <li> Added <code>hasInstallScript</code> property.<br>


</details>


  </td>
  <td><a href="https://github.com/r-sugi/nextjs-tdd-template/pull/220/files#diff-baa935e47c548c1c2375e84a25203d60d0c81efae59289e5f5f5bdf7a4047c9a">+44/-43</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

